### PR TITLE
[FIX] website_sale_stock_auto_publish: Actually inherit the mixin model

### DIFF
--- a/website_sale_stock_auto_publish/models/product_template.py
+++ b/website_sale_stock_auto_publish/models/product_template.py
@@ -5,7 +5,8 @@ from odoo import models
 
 
 class ProductTemplate(models.Model):
-    _inherit = 'product.template'
+    _name = "product.template"
+    _inherit = ["product.template", "website.published.mixin"]
 
     def auto_publishing_value(self):
         self.ensure_one()


### PR DESCRIPTION
Hi @flaenen !

This module caused errors pertaining to the `auto_managed_publishing`field not existing. This commit fixes that.

Moreover, I'm not sure this module really did anything before this fix, but I haven't investigated for long enough.

Pinging @robinkeunen with a request to kindly verify whether this fix makes sense.